### PR TITLE
Avoid warning for ExtUtils::CPPGuess > 0.15

### DIFF
--- a/lib/Test/Alien/CPP.pm
+++ b/lib/Test/Alien/CPP.pm
@@ -102,6 +102,7 @@ sub xs_ok
     };
     $xs->{$stage{$name}}->{$name} = [@old, @new];
   }
+  delete $cppguess{config}; # https://git.io/JesNl
   warn "extra Module::Build option: $_" for keys %cppguess;
 
   $cb ? Test::Alien::xs_ok($xs, $message, $cb) : Test::Alien::xs_ok($xs, $message);


### PR DESCRIPTION
`ExtUtils::CPPGuess` returns a `config` key since 0.15 resulting in a warning of 

> extra Module::Build option: config at ...

As `Test::Alien::CPP` does not use this, it is now simply deleted. The warning condition remains as a canary for other changes with `ExtUtils::CPPGuess`.

## References
* Fixes #3
* https://git.io/JesNl