### PR TITLE
pass config on to Test::Alien

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ copyright_year   = 2017
 version          = 1.01
 
 [@Author::Plicease]
-:version      = 2.21
+:version      = 2.38
 travis_status = 1
 release_tests = 1
 installer     = Author::Plicease::MakeMaker

--- a/lib/Test/Alien/CPP.pm
+++ b/lib/Test/Alien/CPP.pm
@@ -102,6 +102,9 @@ sub xs_ok
     };
     $xs->{$stage{$name}}->{$name} = [@old, @new];
   }
+
+  $xs->{cbuilder_config} = delete $cppguess{config} if defined $cppguess{config};
+
   warn "extra Module::Build option: $_" for keys %cppguess;
 
   $cb ? Test::Alien::xs_ok($xs, $message, $cb) : Test::Alien::xs_ok($xs, $message);

--- a/lib/Test/Alien/CPP.pm
+++ b/lib/Test/Alien/CPP.pm
@@ -104,6 +104,7 @@ sub xs_ok
   }
 
   $xs->{cbuilder_config} = delete $cppguess{config} if defined $cppguess{config};
+  $xs->{cbuilder_check} = 'have_cplusplus';
 
   warn "extra Module::Build option: $_" for keys %cppguess;
 

--- a/lib/Test/Alien/CPP.pm
+++ b/lib/Test/Alien/CPP.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008001;
 use ExtUtils::CppGuess;
-use Test::Alien 1.00 ();
+use Test::Alien 1.88 ();
 use Text::ParseWords qw( shellwords );
 use base qw( Exporter );
 

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -1,7 +1,7 @@
 use Test2::V0 -no_srand => 1;
 use Config;
 
-eval q{ require Test::More };
+eval { require 'Test/More.pm' };
 
 # This .t file is generated.
 # make changes instead to dist.ini
@@ -41,7 +41,7 @@ pass 'okay';
 
 my $max = 1;
 $max = $_ > $max ? $_ : $max for map { length $_ } @modules;
-our $format = "%-${max}s %s"; 
+our $format = "%-${max}s %s";
 
 spacer;
 
@@ -50,13 +50,13 @@ my @keys = sort grep /(MOJO|PERL|\A(LC|HARNESS)_|\A(SHELL|LANG)\Z)/i, keys %ENV;
 if(@keys > 0)
 {
   diag "$_=$ENV{$_}" for @keys;
-  
+
   if($ENV{PERL5LIB})
   {
     spacer;
     diag "PERL5LIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERL5LIB};
-    
+
   }
   elsif($ENV{PERLLIB})
   {
@@ -64,7 +64,7 @@ if(@keys > 0)
     diag "PERLLIB path";
     diag $_ for split $Config{path_sep}, $ENV{PERLLIB};
   }
-  
+
   spacer;
 }
 
@@ -72,9 +72,11 @@ diag sprintf $format, 'perl ', $];
 
 foreach my $module (sort @modules)
 {
-  if(eval qq{ require $module; 1 })
+  my $pm = "$module.pm";
+  $pm =~ s{::}{/}g;
+  if(eval { require $pm; 1 })
   {
-    my $ver = eval qq{ \$$module\::VERSION };
+    my $ver = eval { $module->VERSION };
     $ver = 'undef' unless defined $ver;
     diag sprintf $format, $module, $ver;
   }


### PR DESCRIPTION
Alternate fix to #3 (see commentary on #4), requires patch to AB https://github.com/Perl5-Alien/Alien-Build/pull/140

Great!  Except for now I get this warning instead:

```
t/test_alien_cancompilecpp.t .. ok   
t/test_alien_cpp.t ............ clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
t/test_alien_cpp.t ............ ok   
t/test_alien_cpp__gh1.t ....... 1/? clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
t/test_alien_cpp__gh1.t ....... ok   
```