### PR TITLE
avoid unitialized warnings when resolving extra compiler/link flags i…

### DIFF
--- a/lib/Test/Alien/CPP.pm
+++ b/lib/Test/Alien/CPP.pm
@@ -98,7 +98,9 @@ sub xs_ok
     my @new = ref($cppguess{$name}) eq 'ARRAY' ? @{ delete $cppguess{$name} } : shellwords(delete $cppguess{$name});
     my @old = do {
       my $value = delete $xs->{$stage{$name}}->{$name};
-      ref($value) eq 'ARRAY' ? @$value : shellwords($value);
+      !defined $value            ? ()
+        : ref($value) eq 'ARRAY' ? @$value
+        :                          shellwords($value);
     };
     $xs->{$stage{$name}}->{$name} = [@old, @new];
   }


### PR DESCRIPTION
…n xs_ok

xs_ok merges the compile and link flags passed to it with those provided by ExtUtils::CppGuess. It assumes that if there are extra flags returned by ExtUtils::CppGuess, then there are also extra flags passed to xs_ok.

On some systems, this assumption does not hold, and results in undefined values being passed to Text::ParseWords::shellwords when parsing extra flags passed to xs_ok, causing warnings such as

  use of uninitialized value $line in substitution (s///) at .../Text/ParseWords.pm line 21.

to be emitted.